### PR TITLE
chore: Remove unnecessary permissions in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,6 @@ jobs:
     uses: ./.github/workflows/codeql-security-scan.yml
     with:
       sha: ${{ github.sha }}
-    permissions:
-      contents: read
-      actions: read
-      security-events: write
 
   build_prerelease:
     name: Build & upload artifacts to prerelease draft


### PR DESCRIPTION
Removed permissions for contents, actions, and security-events in the release workflow.