### PR TITLE
chore: Remove unnecessary contents permission from workflow

### DIFF
--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -13,7 +13,6 @@ on:
         value: ${{ jobs.codeql-security-scan.outputs.scan_passed }}
 
 permissions:
-  contents: read
   security-events: write
 
 env:


### PR DESCRIPTION
Removed 'contents: read' permission from the CodeQL security scan workflow.