### PR TITLE
chore: Remove 'fail-on' option from CodeQL scan

### DIFF
--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -51,5 +51,4 @@ jobs:
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
         with:
           category: "/language:go"
-          fail-on: error
           upload: always


### PR DESCRIPTION
Removed the 'fail-on' option from the CodeQL analysis step.